### PR TITLE
Reduce transactions and make evm_mine more resilient

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.json]
+indent_style = space
+indent_size = 4
+
+[*.{js,ts,mjs,mts}]
+indent_style = space
+indent_size = 2

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const ethers = require('ethers'); // eslint-disable-line @typescript-eslint/no-v
 
 const colonyNetworkAddress = process.argv[2];
 
-const provider = new ethers.providers.JsonRpcProvider("http://network-contracts:8545");
+const provider = new ethers.providers.StaticJsonRpcProvider("http://network-contracts:8545");
 
 // eslint-disable-next-line max-len
 const networkAbi = require('../colonyNetwork/artifacts/contracts/colonyNetwork/IColonyNetwork.sol/IColonyNetwork.json')

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const ethers = require('ethers'); // eslint-disable-line @typescript-eslint/no-v
 
 const colonyNetworkAddress = process.argv[2];
 
-const provider = new ethers.providers.StaticJsonRpcProvider("http://network-contracts:8545");
+const provider = new ethers.providers.StaticJsonRpcProvider('http://network-contracts:8545');
 
 // eslint-disable-next-line max-len
 const networkAbi = require('../colonyNetwork/artifacts/contracts/colonyNetwork/IColonyNetwork.sol/IColonyNetwork.json')
@@ -21,10 +21,22 @@ let lastBlockThisServiceMined = null;
 let reputationMonitorActive = false;
 let autominerId;
 
+async function mine(retryTimes = 3) {
+  try {
+    await provider.send('evm_mine');
+  } catch (err) {
+    console.error('Mine failed', err);
+    if (retryTimes) {
+      console.info('Retrying...');
+      await mine(retryTimes - 1);
+    }
+  }
+}
+
 async function forwardTime(seconds) {
   await provider.send('evm_increaseTime', [seconds]);
   if (!autominerId) {
-    await provider.send('evm_mine');
+    await mine();
   }
 }
 
@@ -35,7 +47,7 @@ async function automine(seconds = 0) {
   if (seconds === 0) {
     return;
   } else {
-    autominerId = setInterval(() => provider.send('evm_mine'), seconds * 1000);
+    autominerId = setInterval(mine, seconds * 1000);
   }
 }
 


### PR DESCRIPTION
Sometimes it seems that the hardhat node is overwhelmed with requests. In these cases the reputation monitor would just crash.

In this PR I changed the provider to `StaticJsonProvider` as well as added some try-catch wrappers to not have it crash in these instances.

Shout out to @area who helped me a lot debugging this.